### PR TITLE
solve the duplicate order_id in base_returns table

### DIFF
--- a/models/base/google_drive/base_google_drive__returns.sql
+++ b/models/base/google_drive/base_google_drive__returns.sql
@@ -1,11 +1,28 @@
+WITH table1 AS(
 SELECT _FILE,
        _LINE,
        _MODIFIED AS _MODIFIED_TS,
        _FIVETRAN_SYNCED AS _FIVETRAN_SYNCED_TS,
        RETURNED_AT AS RETURNED_DATE,
        ORDER_ID,
+       RANK() OVER(PARTITION BY ORDER_ID ORDER BY RETURNED_AT) AS ra,
        CASE IS_REFUNDED
             WHEN 'yes' THEN TRUE
             WHEN 'no' THEN FALSE
             END AS IS_REFUNDED
 FROM {{source('google_drive','returns')}}
+)
+
+SELECT _FILE,
+       _LINE,
+       _MODIFIED_TS,
+       _FIVETRAN_SYNCED_TS,
+       RETURNED_DATE,
+       ORDER_ID,
+       IS_REFUNDED
+FROM table1
+WHERE ra = 1
+
+
+
+


### PR DESCRIPTION
If there are multiple rows with the same order_id in the return table, only the one with the earliest return_date will be retained.